### PR TITLE
feat(api): #30 add GET /dashboard/mood-breakdown endpoint

### DIFF
--- a/AuraLogbook.Api/Controllers/MoodController.cs
+++ b/AuraLogbook.Api/Controllers/MoodController.cs
@@ -78,5 +78,25 @@ public class MoodController : ControllerBase
         return Ok(result);
     }
 
+    [HttpGet("dashboard/mood-breakdown")]
+    public async Task<IActionResult> GetMoodBreakdown([FromQuery] bool percent = false)
+    {
+        var userId = GetUserIdFromToken();
+        Dictionary<string, object> result;
+
+        if (percent)
+        {
+            var data = await _moodService.GetMoodBreakdownPercentageAsync(userId);
+            result = data.ToDictionary(kvp => kvp.Key, kvp => (object)kvp.Value);
+        }
+        else
+        {
+            var data = await _moodService.GetMoodBreakdownCountAsync(userId);
+            result = data.ToDictionary(kvp => kvp.Key, kvp => (object)kvp.Value);
+        }
+
+        return Ok(result);
+    }
+
 
 }

--- a/AuraLogbook.Api/Services/IMoodService.cs
+++ b/AuraLogbook.Api/Services/IMoodService.cs
@@ -10,5 +10,7 @@ namespace AuraLogbook.Api.Services
         Task<List<MoodEntry>> GetEntriesForUserAsync(int userId);
         Task<MoodDashboardSummary> GetDashboardSummaryAsync(int userId);
         Task<Dictionary<DateOnly, int>> GetMoodsByDateRangeAsync(int userId, int range);
+        Task<Dictionary<string, int>> GetMoodBreakdownCountAsync(int userId);
+        Task<Dictionary<string, double>> GetMoodBreakdownPercentageAsync(int userId);
     }
 }

--- a/AuraLogbook.Api/Services/MoodService.cs
+++ b/AuraLogbook.Api/Services/MoodService.cs
@@ -125,4 +125,35 @@ public class MoodService : IMoodService
             .GroupBy(e => e.Date)
             .ToDictionary(g => g.Key, g => g.Count());
     }
+
+    /// <summary>
+    /// Returns the count of each mood type for the given user.
+    /// </summary>
+    public async Task<Dictionary<string, int>> GetMoodBreakdownCountAsync(int userId)
+    {
+        var allEntries = await _moodRepo.GetAllByUserAsync(userId);
+
+        return allEntries
+      .SelectMany(e => e.Moods)
+      .GroupBy(m => m.ToString()!)
+      .ToDictionary(g => g.Key, g => g.Count());
+    }
+
+    /// <summary>
+    /// Returns the percentage breakdown of each mood type for the given user.
+    /// </summary>
+    public async Task<Dictionary<string, double>> GetMoodBreakdownPercentageAsync(int userId)
+    {
+        var moodCounts = await GetMoodBreakdownCountAsync(userId);
+        var total = moodCounts.Values.Sum();
+
+        if (total == 0)
+            return new Dictionary<string, double>();
+
+        return moodCounts.ToDictionary(
+            kvp => kvp.Key,
+            kvp => Math.Round((kvp.Value * 100.0) / total, 2)
+        );
+    }
+
 }


### PR DESCRIPTION
Closes #30 
- Returns frequency count of each mood type for authenticated user
- Useful for visualizing mood distribution in charts
- Includes optional percentage calculation for total entries