### PR TITLE
refactor(mood): #98 rename mood types to chakra-synonym labels across…

### DIFF
--- a/AuraLogbook.Api/Data/moods.json
+++ b/AuraLogbook.Api/Data/moods.json
@@ -386,5 +386,16 @@
     ],
     "Comment": "I\u0027m proud of the progress I\u0027m making with this app!",
     "CreatedAt": "2025-06-23T19:08:39.1919652Z"
+  },
+  {
+    "Id": 43,
+    "UserId": 12,
+    "Date": "2025-06-23",
+    "Moods": [
+      0,
+      13
+    ],
+    "Comment": null,
+    "CreatedAt": "2025-06-24T01:22:01.6415956Z"
   }
 ]

--- a/AuraLogbook.Api/Models/Enums/MoodType.cs
+++ b/AuraLogbook.Api/Models/Enums/MoodType.cs
@@ -2,19 +2,19 @@
 
 public enum MoodType
 {
-    Joyful,
-    Content,
-    Peaceful,
-    Motivated,
-    Tired,
-    Stressed,
+    Empowered,
+    Centered,
+    Harmonious,
+    Flowing,
+    Weary,
+    Tense,
     Frustrated,
-    Anxious,
-    Lonely,
-    Sad,
-    Angry,
-    Overwhelmed,
-    Grateful,
-    Hopeful,
-    Meh
+    Restless,
+    Disconnected,
+    Heavy,
+    Charged,
+    Scattered,
+    Abundant,
+    Visionary,
+    Neutral
 }

--- a/aura-ui/src/features/mood/models/aura/AuraMoodMap.ts
+++ b/aura-ui/src/features/mood/models/aura/AuraMoodMap.ts
@@ -10,78 +10,78 @@ export interface AuraMoodMeta {
 }
 
 export const AuraMoodMap: Record<MoodType, AuraMoodMeta> = {
-  Joyful: {
-    icon: MoodIcons.Joyful,
+  Empowered: {
+    icon: MoodIcons.Empowered,
     auraColor: AuraColor.Yellow,
     chakra: Chakra.SolarPlexus,
   },
-  Content: {
-    icon: MoodIcons.Content,
+  Centered: {
+    icon: MoodIcons.Centered,
     auraColor: AuraColor.Yellow,
     chakra: Chakra.SolarPlexus,
   },
-  Peaceful: {
-    icon: MoodIcons.Peaceful,
+  Harmonious: {
+    icon: MoodIcons.Harmonious,
     auraColor: AuraColor.Blue,
     chakra: Chakra.Throat,
   },
-  Motivated: {
-    icon: MoodIcons.Motivated,
+  Flowing: {
+    icon: MoodIcons.Flowing,
     auraColor: AuraColor.Orange,
     chakra: Chakra.Sacral,
   },
-  Tired: {
-    icon: MoodIcons.Tired,
+  Weary: {
+    icon: MoodIcons.Weary,
     auraColor: AuraColor.Gray,
     chakra: Chakra.Root,
   },
-  Stressed: {
-    icon: MoodIcons.Stressed,
+  Tense: {
+    icon: MoodIcons.Tense,
     auraColor: AuraColor.Red,
     chakra: Chakra.Root,
   },
-  Frustrated: {
-    icon: MoodIcons.Frustrated,
+  Blocked: {
+    icon: MoodIcons.Blocked,
     auraColor: AuraColor.Red,
     chakra: Chakra.Root,
   },
-  Anxious: {
-    icon: MoodIcons.Anxious,
+  Restless: {
+    icon: MoodIcons.Restless,
     auraColor: AuraColor.Indigo,
     chakra: Chakra.ThirdEye,
   },
-  Lonely: {
-    icon: MoodIcons.Lonely,
+  Disconnected: {
+    icon: MoodIcons.Disconnected,
     auraColor: AuraColor.Indigo,
     chakra: Chakra.Heart,
   },
-  Sad: {
-    icon: MoodIcons.Sad,
+  Heavy: {
+    icon: MoodIcons.Heavy,
     auraColor: AuraColor.Blue,
     chakra: Chakra.Heart,
   },
-  Angry: {
-    icon: MoodIcons.Angry,
+  Charged: {
+    icon: MoodIcons.Charged,
     auraColor: AuraColor.Red,
     chakra: Chakra.Root,
   },
-  Overwhelmed: {
-    icon: MoodIcons.Overwhelmed,
+  Scattered: {
+    icon: MoodIcons.Scattered,
     auraColor: AuraColor.Violet,
     chakra: Chakra.Crown,
   },
-  Grateful: {
-    icon: MoodIcons.Grateful,
+  Abundant: {
+    icon: MoodIcons.Abundant,
     auraColor: AuraColor.Green,
     chakra: Chakra.Heart,
   },
-  Hopeful: {
-    icon: MoodIcons.Hopeful,
+  Visionary: {
+    icon: MoodIcons.Visionary,
     auraColor: AuraColor.Pink,
     chakra: Chakra.Crown,
   },
-  Meh: {
-    icon: MoodIcons.Meh,
+  Neutral: {
+    icon: MoodIcons.Neutral,
     auraColor: AuraColor.Gray,
     chakra: Chakra.SolarPlexus,
   },

--- a/aura-ui/src/features/mood/models/aura/MoodIcons.ts
+++ b/aura-ui/src/features/mood/models/aura/MoodIcons.ts
@@ -1,20 +1,21 @@
 import type { MoodType } from "../schema/MoodType";
+
 export const MoodIcons: Record<MoodType, string> = {
-  Joyful: "😄",
-  Content: "😊",
-  Peaceful: "🕊️",
-  Motivated: "🚀",
-  Tired: "😴",
-  Stressed: "😣",
-  Frustrated: "😤",
-  Anxious: "😰",
-  Lonely: "😔",
-  Sad: "😢",
-  Angry: "😠",
-  Overwhelmed: "🤯",
-  Grateful: "🙏",
-  Hopeful: "🌈",
-  Meh: "😐",
+  Empowered: "😄", // Joyful
+  Centered: "😊", // Content
+  Harmonious: "🕊️", // Peaceful
+  Flowing: "🚀", // Motivated
+  Weary: "😴", // Tired → Weary
+  Tense: "😣", // Stressed
+  Blocked: "😤", // Frustrated
+  Restless: "😰", // Anxious
+  Disconnected: "😔", // Lonely
+  Heavy: "😢", // Sad
+  Charged: "😠", // Angry
+  Scattered: "🤯", // Overwhelmed
+  Abundant: "🙏", // Grateful
+  Visionary: "🌈", // Hopeful
+  Neutral: "😐", // Meh
 } as const;
 
 export type MoodIcon = (typeof MoodIcons)[MoodType];

--- a/aura-ui/src/features/mood/models/schema/MoodType.ts
+++ b/aura-ui/src/features/mood/models/schema/MoodType.ts
@@ -4,39 +4,40 @@
  * Union type representing allowed mood values.
  */
 export type MoodType =
-  | "Joyful"
-  | "Content"
-  | "Peaceful"
-  | "Motivated"
-  | "Tired"
-  | "Stressed"
-  | "Frustrated"
-  | "Anxious"
-  | "Lonely"
-  | "Sad"
-  | "Angry"
-  | "Overwhelmed"
-  | "Grateful"
-  | "Hopeful"
-  | "Meh";
+  | "Empowered"      // Joyful: personal power & confidence
+  | "Centered"       // Content: inner balance & compassion
+  | "Harmonious"     // Peaceful: clear expression & calm
+  | "Flowing"        // Motivated: creative flow & inspiration
+  | "Weary"       // Tired: need for rest & stability
+  | "Tense"          // Stressed: survival tension
+  | "Blocked"        // Frustrated: stuck energy
+  | "Restless"       // Anxious: overactive mind
+  | "Disconnected"   // Lonely: closed-off heart
+  | "Heavy"          // Sad: emotional heaviness
+  | "Charged"        // Angry: fiery drive
+  | "Scattered"      // Overwhelmed: scattered roots
+  | "Abundant"       // Grateful: sense of plenty
+  | "Visionary"      // Hopeful: big-picture optimism
+  | "Neutral";       // Meh: reset & neutrality
+
 
 /**
  * List of mood types as an array (for dropdowns, loops, etc.)
  */
 export const MoodTypes: MoodType[] = [
-  "Joyful",
-  "Content",
-  "Peaceful",
-  "Motivated",
-  "Tired",
-  "Stressed",
-  "Frustrated",
-  "Anxious",
-  "Lonely",
-  "Sad",
-  "Angry",
-  "Overwhelmed",
-  "Grateful",
-  "Hopeful",
-  "Meh"
+  "Empowered",
+  "Centered",
+  "Harmonious",
+  "Flowing",
+  "Weary",
+  "Tense",
+  "Blocked",
+  "Restless",
+  "Disconnected",
+  "Heavy",
+  "Charged",
+  "Scattered",
+  "Abundant",
+  "Visionary",
+  "Neutral",
 ];


### PR DESCRIPTION
… projects

Replaced existing mood labels (Joyful, Content, Peaceful, Motivated, Tired, etc.) with chakra-inspired synonyms (Empowered, Centered, Harmonious, Flowing, Weary, etc.) in both frontend and backend. Updated MoodType definitions, MoodIcons mapping, API contracts, and related tests to match the new labels.
Closes #98 