### PR TITLE
159 test add smoke tests for core frontend views

### DIFF
--- a/aura-ui/src/pages/tests/Dashboard.test.tsx
+++ b/aura-ui/src/pages/tests/Dashboard.test.tsx
@@ -6,6 +6,7 @@ import {
 } from "../../test/testUtilities";
 import Dashboard from "../Dashboard";
 
+// This mocks useAppSelector
 vi.mock("../../store/hooks", async () => {
   const actual = await vi.importActual<typeof import("../../store/hooks")>(
     "../../store/hooks"
@@ -21,6 +22,7 @@ vi.mock("../../store/hooks", async () => {
   };
 });
 
+// This mocks useGetCurrentUserQuery
 vi.mock("../../store/authApi", async () => {
   const actual = await vi.importActual<typeof import("../../store/authApi")>(
     "../../store/authApi"
@@ -34,6 +36,7 @@ vi.mock("../../store/authApi", async () => {
   };
 });
 
+// This mocks all the moodApi hooks used in the Dashboard
 vi.mock("../../store/moodApi", () => ({
   useGetDashboardSummaryQuery: () => ({
     isLoading: false,
@@ -65,6 +68,7 @@ vi.mock("../../store/moodApi", () => ({
   }),
 }));
 
+// This mocks the zodiacApi hook used in the Dashboard
 vi.mock("../../store/auraApi", () => ({
   useGetZodiacInsightQuery: () => ({
     isLoading: false,
@@ -81,14 +85,17 @@ vi.mock("../../store/auraApi", () => ({
   }),
 }));
 
+// Mock the child components used in the Dashboard
 vi.mock("../../components/weather/WeatherCard", () => ({
   default: () => <div data-testid="weather-card">Weather Card</div>,
 }));
 
+// Mock the chart components to avoid rendering actual charts in the test
 vi.mock("../../components/dashboard/MoodPieChart", () => ({
   default: () => <div data-testid="mood-pie-chart">Mood Pie Chart</div>,
 }));
 
+// Mock the MoodStatCard to display the title and value for testing purposes
 vi.mock("../../components/dashboard/MoodStatCard", () => ({
   default: ({ title, value }: { title: string; value: string }) => (
     <div data-testid="mood-stat-card">

--- a/aura-ui/src/pages/tests/Dashboard.test.tsx
+++ b/aura-ui/src/pages/tests/Dashboard.test.tsx
@@ -1,0 +1,132 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createAuthenticatedState,
+  renderWithProviders,
+} from "../../test/testUtilities";
+import Dashboard from "../Dashboard";
+
+vi.mock("../../store/hooks", async () => {
+  const actual = await vi.importActual<typeof import("../../store/hooks")>(
+    "../../store/hooks"
+  );
+
+  return {
+    ...actual,
+    useAppSelector: () => ({
+      displayName: "Gem",
+      auraColor: "blue",
+      selectedPathway: "Mindfulness",
+    }),
+  };
+});
+
+vi.mock("../../store/authApi", async () => {
+  const actual = await vi.importActual<typeof import("../../store/authApi")>(
+    "../../store/authApi"
+  );
+
+  return {
+    ...actual,
+    useGetCurrentUserQuery: () => ({
+      isLoading: false,
+    }),
+  };
+});
+
+vi.mock("../../store/moodApi", () => ({
+  useGetDashboardSummaryQuery: () => ({
+    isLoading: false,
+    data: {
+      totalEntries: 12,
+      mostFrequentMood: "Calm",
+      currentStreak: 4,
+      lastEntryDate: "2025-06-18",
+    },
+  }),
+  useGetMoodBreakdownQuery: () => ({
+    isLoading: false,
+    data: [
+      {
+        mood: "Calm",
+        count: 5,
+        percent: 42,
+      },
+    ],
+  }),
+  useGetMoodsByDateRangeQuery: () => ({
+    isLoading: false,
+    data: [
+      {
+        date: "2025-06-18",
+        count: 2,
+      },
+    ],
+  }),
+}));
+
+vi.mock("../../store/auraApi", () => ({
+  useGetZodiacInsightQuery: () => ({
+    isLoading: false,
+    data: {
+      sign: "Virgo",
+      element: "Earth",
+      description: "Grounded, reflective energy.",
+      insights: [
+        {
+          message: "Take your time and trust your rhythm.",
+        },
+      ],
+    },
+  }),
+}));
+
+vi.mock("../../components/weather/WeatherCard", () => ({
+  default: () => <div data-testid="weather-card">Weather Card</div>,
+}));
+
+vi.mock("../../components/dashboard/MoodPieChart", () => ({
+  default: () => <div data-testid="mood-pie-chart">Mood Pie Chart</div>,
+}));
+
+vi.mock("../../components/dashboard/MoodStatCard", () => ({
+  default: ({ title, value }: { title: string; value: string }) => (
+    <div data-testid="mood-stat-card">
+      <span>{title}</span>
+      <span>{value}</span>
+    </div>
+  ),
+}));
+
+vi.mock("../../components/dashboard/MoodTimeLineChart", () => ({
+  default: () => <div data-testid="mood-timeline-chart">Mood Timeline Chart</div>,
+}));
+
+vi.mock("../../util/timeGreeting", () => ({
+  getTimeGreeting: () => "Good morning",
+}));
+
+describe("Dashboard", () => {
+  it("should render the dashboard with user, mood, weather, and zodiac sections", () => {
+    renderWithProviders(<Dashboard />, {
+      preloadedState: createAuthenticatedState(),
+    });
+
+    expect(screen.getByText(/good morning, gem!/i)).toBeInTheDocument();
+    expect(screen.getByText(/my pathway/i)).toBeInTheDocument();
+    expect(screen.getByText(/mindfulness/i)).toBeInTheDocument();
+    expect(screen.getByText(/virgo • earth/i)).toBeInTheDocument();
+    expect(screen.getByText(/grounded, reflective energy/i)).toBeInTheDocument();
+    expect(screen.getByText(/take your time and trust your rhythm/i)).toBeInTheDocument();
+    expect(screen.getByText(/total entries/i)).toBeInTheDocument();
+    expect(screen.getByText("12")).toBeInTheDocument();
+    expect(screen.getByText(/most frequent mood/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/calm/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/current streak/i)).toBeInTheDocument();
+    expect(screen.getByText(/4 days/i)).toBeInTheDocument();
+    expect(screen.getByText(/last entry/i)).toBeInTheDocument();
+    expect(screen.getByTestId("weather-card")).toBeInTheDocument();
+    expect(screen.getByTestId("mood-pie-chart")).toBeInTheDocument();
+    expect(screen.getByTestId("mood-timeline-chart")).toBeInTheDocument();
+  });
+});

--- a/aura-ui/src/pages/tests/Home.test.tsx
+++ b/aura-ui/src/pages/tests/Home.test.tsx
@@ -1,0 +1,39 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders } from "../../test/testUtilities";
+import HomePage from "../Home";
+
+/**
+ * Mocks the feature card section so this smoke test can focus on the
+ * HomePage layout and visible landing page content rather than the
+ * implementation details of the nested AuraFeatureCards component.
+ */
+vi.mock("../../components/home/AuraFeatureCard", () => ({
+  default: () => <div data-testid="aura-feature-cards">Aura Feature Cards</div>,
+}));
+
+describe("HomePage", () => {
+  /**
+   * Verifies that the HomePage renders its primary landing page content,
+   * including the heading, supporting copy, feature card section, call-to-action,
+   * and closing quote.
+   */
+  it("should render the home page content", () => {
+    renderWithProviders(<HomePage />);
+
+    expect(
+      screen.getByRole("heading", { name: /welcome to aura logbook/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/your energy tells a story/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/aura logbook isn’t just about tracking mood/i)
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("aura-feature-cards")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /start your aura journey/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/when you track your aura, you tune into your truth/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/aura-ui/src/pages/tests/Home.test.tsx
+++ b/aura-ui/src/pages/tests/Home.test.tsx
@@ -8,7 +8,7 @@ import HomePage from "../Home";
  * HomePage layout and visible landing page content rather than the
  * implementation details of the nested AuraFeatureCards component.
  */
-vi.mock("../../components/home/AuraFeatureCard", () => ({
+vi.mock("@/components/home/AuraFeatureCard", () => ({
   default: () => <div data-testid="aura-feature-cards">Aura Feature Cards</div>,
 }));
 

--- a/aura-ui/src/pages/tests/LoginForm.test.tsx
+++ b/aura-ui/src/pages/tests/LoginForm.test.tsx
@@ -1,0 +1,40 @@
+
+
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders } from "../../test/testUtilities";
+import { LoginForm } from "../Login";
+
+vi.mock("../../hooks/useToast", () => ({
+  useToast: () => ({
+    showToast: vi.fn(),
+  }),
+}));
+
+describe("LoginForm", () => {
+  it("should render the login form", () => {
+    renderWithProviders(<LoginForm showTitle />);
+
+    expect(
+      screen.getByRole("heading", { name: /sign in/i })
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /login/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /forgot password/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /sign up/i })).toBeInTheDocument();
+  });
+
+  it("should render without the optional title", () => {
+    renderWithProviders(<LoginForm />);
+
+    expect(
+      screen.queryByRole("heading", { name: /sign in/i })
+    ).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /login/i })).toBeInTheDocument();
+  });
+});

--- a/aura-ui/src/pages/tests/LoginForm.test.tsx
+++ b/aura-ui/src/pages/tests/LoginForm.test.tsx
@@ -1,15 +1,23 @@
-
-
 import { screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { renderWithProviders } from "../../test/testUtilities";
 import { LoginForm } from "../Login";
 
-vi.mock("../../hooks/useToast", () => ({
-  useToast: () => ({
-    showToast: vi.fn(),
-  }),
-}));
+/**
+ * Keeps the real ToastProvider available for renderWithProviders while
+ * replacing useToast with a mock so the smoke test does not trigger real
+ * toast behavior.
+ */
+vi.mock("../../hooks/useToast", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../hooks/useToast")>();
+
+  return {
+    ...actual,
+    useToast: () => ({
+      showToast: vi.fn(),
+    }),
+  };
+});
 
 describe("LoginForm", () => {
   it("should render the login form", () => {

--- a/aura-ui/src/pages/tests/MoodEntryForm.test.tsx
+++ b/aura-ui/src/pages/tests/MoodEntryForm.test.tsx
@@ -1,0 +1,36 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders } from "../../test/testUtilities";
+import MoodEntryForm from "@/components/MoodEntryForm";
+
+vi.mock("../../hooks/useToast", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../hooks/useToast")>();
+
+  return {
+    ...actual,
+    useToast: () => ({
+      showToast: vi.fn(),
+    }),
+  };
+});
+
+vi.mock("@/components/MoodEntryFormFields", () => ({
+  default: () => (
+    <div data-testid="mood-entry-form-fields">Mood Entry Form Fields</div>
+  ),
+}));
+
+describe("MoodEntryForm", () => {
+  /**
+   * Verifies that the MoodEntryForm renders the page heading and delegates
+   * the actual form controls to the MoodEntryFormFields child component.
+   */
+  it("should render the mood entry form", () => {
+    renderWithProviders(<MoodEntryForm />);
+
+    expect(
+      screen.getByRole("heading", { name: /log your mood/i })
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("mood-entry-form-fields")).toBeInTheDocument();
+  });
+});

--- a/aura-ui/src/pages/tests/MoodHistory.test.tsx
+++ b/aura-ui/src/pages/tests/MoodHistory.test.tsx
@@ -1,0 +1,102 @@
+import { screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderWithProviders } from "../../test/testUtilities";
+import MoodHistoryPage from "../../components/history/MoodHistory";
+import { MoodApi } from "@/api/MoodApi";
+import type { MoodType } from "@/features/mood/models/schema";
+
+vi.mock("@/api/MoodApi", () => ({
+  MoodApi: {
+    getAllMoods: vi.fn(),
+    deleteMood: vi.fn(),
+  },
+}));
+
+vi.mock("../../hooks/useToast", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../hooks/useToast")>();
+
+  return {
+    ...actual,
+    useToast: () => ({
+      showToast: vi.fn(),
+    }),
+  };
+});
+
+vi.mock("@mui/x-date-pickers", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@mui/x-date-pickers")>();
+
+  return {
+    ...actual,
+    DatePicker: ({ label }: { label: string }) => (
+      <input aria-label={label} readOnly />
+    ),
+  };
+});
+
+vi.mock("../../components/history/MoodCard", () => ({
+  MoodCard: ({ entry }: { entry: { comment?: string | null } }) => (
+    <div data-testid="mood-card">{entry.comment ?? "Mood entry"}</div>
+  ),
+}));
+
+vi.mock("../../components/MoodUpdateModal", () => ({
+  default: () => <div data-testid="mood-update-modal">Mood Update Modal</div>,
+}));
+
+vi.mock("../../components/DeleteConfirmDialog", () => ({
+  default: () => (
+    <div data-testid="delete-confirm-dialog">Delete Confirm Dialog</div>
+  ),
+}));
+
+const mockedMoodApi = vi.mocked(MoodApi);
+
+const testData = {
+  moodEntries: [
+    {
+      id: 1,
+      userId: 1,
+      date: "2025-06-18",
+      moods: ["Harmonious", "Centered"] as MoodType[],
+      comment: "Feeling grounded.",
+      createdAt: "2025-06-18T14:38:13Z",
+    },
+  ],
+};
+
+describe("MoodHistoryPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedMoodApi.getAllMoods.mockResolvedValue(testData.moodEntries);
+  });
+
+  /**
+   * Smoke test for the Mood History page.
+   *
+   * This test checks that the page can load without crashing, shows the main
+   * Mood History heading, displays the date filter controls, and renders at
+   * least one mood card after the mocked mood history API call finishes.
+   *
+   * The real MoodCard, date picker internals, delete dialog, and update modal
+   * are not tested here. Those pieces are mocked so this test can stay focused
+   * on whether the MoodHistoryPage itself shows up correctly.
+   */
+  it("should render the mood history page", async () => {
+    renderWithProviders(<MoodHistoryPage />);
+
+    expect(
+      screen.getByRole("heading", { name: /mood history/i })
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/start date/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/end date/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /filter/i })).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mood-card")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/feeling grounded/i)).toBeInTheDocument();
+    expect(mockedMoodApi.getAllMoods).toHaveBeenCalledWith(undefined, undefined);
+  });
+});

--- a/aura-ui/src/pages/tests/NotFound.test.tsx
+++ b/aura-ui/src/pages/tests/NotFound.test.tsx
@@ -1,0 +1,20 @@
+
+
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import NotFound from "../NotFound";
+import { renderWithProviders } from "../../test/testUtilities";
+
+describe("NotFound", () => {
+  /**
+   * Verifies that the NotFound page renders the fallback message shown when
+   * a user navigates to an unsupported route.
+   */
+  it("should render the not found page", () => {
+    renderWithProviders(<NotFound />);
+
+    expect(
+      screen.getByRole("heading", { name: /not found/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/aura-ui/src/pages/tests/RegisterForm.test.tsx
+++ b/aura-ui/src/pages/tests/RegisterForm.test.tsx
@@ -2,26 +2,36 @@
 
 import { screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { renderWithProviders } from "../../test/testUtilities";
+import { renderWithProviders } from "@/test/testUtilities";
 import RegisterForm from "../Register";
 
-vi.mock("../../hooks/useToast", () => ({
-  useToast: () => ({
-    showToast: vi.fn(),
-  }),
-}));
+vi.mock("../../hooks/useToast", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../hooks/useToast")>();
 
-vi.mock("../../components/MyPathwaySelector", () => ({
+  return {
+    ...actual,
+    useToast: () => ({
+      showToast: vi.fn(),
+    }),
+  };
+});
+
+vi.mock("@/components/MyPathwaySelector", () => ({
   MyPathwaySelector: () => (
     <div data-testid="pathway-selector">Spiritual Pathway</div>
   ),
 }));
 
-vi.mock("@mui/x-date-pickers", () => ({
-  DatePicker: ({ label }: { label: string }) => (
-    <input aria-label={label} readOnly />
-  ),
-}));
+vi.mock("@mui/x-date-pickers", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@mui/x-date-pickers")>();
+
+  return {
+    ...actual,
+    DatePicker: ({ label }: { label: string }) => (
+      <input aria-label={label} readOnly />
+    ),
+  };
+});
 
 describe("RegisterForm", () => {
   it("should render the register form", () => {

--- a/aura-ui/src/pages/tests/RegisterForm.test.tsx
+++ b/aura-ui/src/pages/tests/RegisterForm.test.tsx
@@ -1,0 +1,44 @@
+
+
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders } from "../../test/testUtilities";
+import RegisterForm from "../Register";
+
+vi.mock("../../hooks/useToast", () => ({
+  useToast: () => ({
+    showToast: vi.fn(),
+  }),
+}));
+
+vi.mock("../../components/MyPathwaySelector", () => ({
+  MyPathwaySelector: () => (
+    <div data-testid="pathway-selector">Spiritual Pathway</div>
+  ),
+}));
+
+vi.mock("@mui/x-date-pickers", () => ({
+  DatePicker: ({ label }: { label: string }) => (
+    <input aria-label={label} readOnly />
+  ),
+}));
+
+describe("RegisterForm", () => {
+  it("should render the register form", () => {
+    renderWithProviders(<RegisterForm />);
+
+    expect(
+      screen.getByRole("heading", { name: /create an account/i })
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/confirm password/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/display name/i)).toBeInTheDocument();
+    expect(screen.getByTestId("pathway-selector")).toBeInTheDocument();
+    expect(screen.getByLabelText(/birthday/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /register/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /login/i })).toBeInTheDocument();
+  });
+});

--- a/aura-ui/src/test/testUtilities.tsx
+++ b/aura-ui/src/test/testUtilities.tsx
@@ -3,8 +3,14 @@ import { render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { configureStore } from "@reduxjs/toolkit";
+import { CssBaseline, ThemeProvider } from "@mui/material";
+import { LocalizationProvider } from "@mui/x-date-pickers";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import { ToastProvider } from "../hooks/useToast";
+import { getAuraTheme } from "../theme";
 import authReducer from "../store/slices/authSlice";
 import uiReducer from "../store/slices/uiSlice";
+import { AuraColor } from "@/features/mood/models/aura";
 
 /**
  * Utility function to render a component with Redux and React Router context for testing.
@@ -13,11 +19,13 @@ import uiReducer from "../store/slices/uiSlice";
  * @param options - Optional configuration for the test environment, including initial route and preloaded Redux state.
  * @returns An object containing the Redux store and the result of the render function.
  * @note
- * 1. Creates a fake Redux store for the test
- * 2. Wraps the component in Redux Provider
- * 3. Wraps the component in MemoryRouter
- * 4. Renders the component using React Testing Library
- * 5. Returns the store too, in case the test needs to inspect state
+ *  1. Creates a fake Redux store for the test
+ *  2. Wraps the component in Redux Provider
+ *  3. Wraps the component in the Aura MUI theme
+ *  4. Adds ToastProvider and LocalizationProvider context
+ *  5. Wraps the component in MemoryRouter
+ *  6. Renders the component using React Testing Library
+ *  7. Returns the store too, in case the test needs to inspect state
  *
  * @example
  * renderWithProviders(<MyComponent />, {
@@ -29,6 +37,8 @@ import uiReducer from "../store/slices/uiSlice";
  *       profile: null,
  *     },
  *   },
+ *   auraColor: "blue",
+ *   auraIntensity: 500,
  * });
  *
  * expect(screen.getByText("Expected text")).toBeInTheDocument();
@@ -36,11 +46,18 @@ import uiReducer from "../store/slices/uiSlice";
 type RenderWithProvidersOptions = {
   route?: string;
   preloadedState?: Parameters<typeof configureStore>[0]["preloadedState"];
+  auraColor?: AuraColor;
+  auraIntensity?: number;
 };
 
 export function renderWithProviders(
   ui: ReactElement,
-  { route = "/", preloadedState }: RenderWithProvidersOptions = {}
+  {
+    route = "/",
+    preloadedState,
+    auraColor = AuraColor.Blue,
+    auraIntensity = 500,
+  }: RenderWithProvidersOptions = {}
 ) {
   const store = configureStore({
     reducer: {
@@ -50,11 +67,20 @@ export function renderWithProviders(
     preloadedState,
   });
 
+  const theme = getAuraTheme(auraColor, auraIntensity);
+
   return {
     store,
     ...render(
       <Provider store={store}>
-        <MemoryRouter initialEntries={[route]}>{ui}</MemoryRouter>
+        <ThemeProvider theme={theme}>
+          <CssBaseline />
+          <ToastProvider>
+            <LocalizationProvider dateAdapter={AdapterDayjs}>
+              <MemoryRouter initialEntries={[route]}>{ui}</MemoryRouter>
+            </LocalizationProvider>
+          </ToastProvider>
+        </ThemeProvider>
       </Provider>
     ),
   };


### PR DESCRIPTION
Added smoke tests for the main frontend views and protected experience components.

This provides baseline confidence that key UI screens render successfully inside the app’s required provider context.
closes #159 